### PR TITLE
Update access checks

### DIFF
--- a/classes/UDFCheck/class.UDFCheckGUI.php
+++ b/classes/UDFCheck/class.UDFCheckGUI.php
@@ -40,9 +40,9 @@ class UDFCheckGUI {
      */
 	public function __construct(UserSettingsGUI|UDFCheckGUI $parent_gui) {
         global $DIC;
-        //is Admin?
-        if(in_array(2, $DIC->rbac()->review()->assignedGlobalRoles($DIC->user()->getId())) === false) {
-            echo "no Permission";
+        //check Access
+        if(!ilUserDefaultsPlugin::grantAccess()) {
+            echo "no UDFCheck Permission";
             exit;
         };
 

--- a/classes/UserSearch/class.usrdefUserGUI.php
+++ b/classes/UserSearch/class.usrdefUserGUI.php
@@ -32,9 +32,9 @@ class usrdefUserGUI
     public function __construct()
     {
         global $DIC;
-        //is Admin?
-        if(in_array(2, $DIC->rbac()->review()->assignedGlobalRoles($DIC->user()->getId())) === false) {
-            echo "no Permission";
+        //Check Access
+        if(!ilUserDefaultsPlugin::grantAccess()) {
+            echo "no Search Permission";
             exit;
         };
 

--- a/classes/UserSetting/class.UserSettingsGUI.php
+++ b/classes/UserSetting/class.UserSettingsGUI.php
@@ -55,9 +55,9 @@ class UserSettingsGUI
     public function __construct()
     {
         global $DIC;
-        //is Admin?
-        if(in_array(2, $DIC->rbac()->review()->assignedGlobalRoles($DIC->user()->getId())) === false) {
-            echo "no Permission";
+        //is access granted
+        if(!ilUserDefaultsPlugin::grantAccess()) {
+            echo "no Settings Permission";
             exit;
         };
 

--- a/classes/class.ilUserDefaultsConfigGUI.php
+++ b/classes/class.ilUserDefaultsConfigGUI.php
@@ -23,8 +23,8 @@ class ilUserDefaultsConfigGUI extends ilPluginConfigGUI {
 	 */
 	public function __construct() {
         global $DIC;
-        //is Admin?
-        if(in_array(2, $DIC->rbac()->review()->assignedGlobalRoles($DIC->user()->getId())) === false) {
+        //Access granted?
+        if(!ilUserDefaultsPlugin::grantAccess()) {
             echo "no Permission";
             exit;
         };

--- a/classes/class.ilUserDefaultsConfigGUI.php
+++ b/classes/class.ilUserDefaultsConfigGUI.php
@@ -25,7 +25,7 @@ class ilUserDefaultsConfigGUI extends ilPluginConfigGUI {
         global $DIC;
         //Access granted?
         if(!ilUserDefaultsPlugin::grantAccess()) {
-            echo "no Permission";
+            echo "no Plugin Permission";
             exit;
         };
 

--- a/classes/class.ilUserDefaultsPlugin.php
+++ b/classes/class.ilUserDefaultsPlugin.php
@@ -174,7 +174,12 @@ class ilUserDefaultsPlugin extends ilEventHookPlugin {
         return $this->getDirectory()."/templates/images/".$imageName;
     }
 
-
+    	public static function grantAccess():bool {
+	    global $DIC;
+	 	// check if user is allowed to configure UserDefauts
+		// since major parts of the plugin assign roles to users the capability to assign roles in useradministration is checked
+	    return ($DIC->rbac()->system()->checkAccess("edit_roleassignment",USER_FOLDER_ID);
+    	}
     /**
      * @inheritDoc
      */

--- a/classes/class.ilUserDefaultsPlugin.php
+++ b/classes/class.ilUserDefaultsPlugin.php
@@ -178,7 +178,7 @@ class ilUserDefaultsPlugin extends ilEventHookPlugin {
 	    global $DIC;
 	 	// check if user is allowed to configure UserDefauts
 		// since major parts of the plugin assign roles to users the capability to assign roles in useradministration is checked
-	    return ($DIC->rbac()->system()->checkAccess("edit_roleassignment",USER_FOLDER_ID);
+	    return ($DIC->rbac()->system()->checkAccess("edit_roleassignment",USER_FOLDER_ID));
     	}
     /**
      * @inheritDoc

--- a/classes/class.ilUserDefaultsPlugin.php
+++ b/classes/class.ilUserDefaultsPlugin.php
@@ -178,6 +178,7 @@ class ilUserDefaultsPlugin extends ilEventHookPlugin {
 	    global $DIC;
 	 	// check if user is allowed to configure UserDefauts
 		// since major parts of the plugin assign roles to users the capability to assign roles in useradministration is checked
+		// write would check if user can edit settings
 	    return ($DIC->rbac()->system()->checkAccess("edit_roleassignment",USER_FOLDER_ID));
     	}
     /**

--- a/classes/class.ilUserDefaultsRestApiGUI.php
+++ b/classes/class.ilUserDefaultsRestApiGUI.php
@@ -36,8 +36,8 @@ class ilUserDefaultsRestApiGUI
     {
         global $DIC;
         $this->ctrl = $DIC->ctrl();
-        //is Admin?
-        if(in_array(2, $DIC->rbac()->review()->assignedGlobalRoles($DIC->user()->getId())) === false) {
+        // fix DH: Has permission
+        if (!ilUserDefaultsPlugin::grantAccess()) {
             echo "no Permission";
             exit;
         };


### PR DESCRIPTION
the plugin checked, if the user holds the global admin role. To enable persons who have proper authority, but not the global admin role to configure the plungin settings, I introduced a new function "grant access(): bool" to the plugin class. The checks fpr the pluginGUI, UDFChecks, UserSettings and UserSearch are updated to use the new function.

The Function itself checks if the user is allowed to edit roles in ILIAS user adminstration, since most functions of the plugin (de-)assign roles to users. Probably this could be extended to check orgUnit assignment capabilities, too. 
if other capabilities should be honoured, this can be achieved in one place now.

I did not touch the REST API related classes since I am not sure which check should be placed here. 